### PR TITLE
Invoke onStart and onStop for MapView

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
   compile 'com.github.skedgo:rx-utils:v1.0'
   compile "com.android.support:appcompat-v7:23.3.0"
   compile "com.android.support:design:23.3.0"
-  compile "com.google.android.gms:play-services-maps:8.4.0"
+  compile "com.google.android.gms:play-services-maps:9.6.1"
   compile 'com.jakewharton:butterknife:8.0.1'
   apt 'com.jakewharton:butterknife-compiler:8.0.1'
 }

--- a/src/main/java/skedgo/common/view/BindableSingleMapFragment.java
+++ b/src/main/java/skedgo/common/view/BindableSingleMapFragment.java
@@ -20,6 +20,16 @@ public abstract class BindableSingleMapFragment extends ButterKnifeFragment {
   private static final String KEY_MAP_STATE = "mapState";
   protected MapView mapView;
 
+  @Override public void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override public void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
   @Override public void onResume() {
     super.onResume();
     mapView.onResume();


### PR DESCRIPTION
### What is new in this Pull Request ?

- Dependency `com.google.android.gms:play-services-maps` version bump to 9.6.1
- Forward `onStart`, `onStop` callback to `MapView`